### PR TITLE
Bug fix for light building specific sub levels with the resave packages commandlet

### DIFF
--- a/Engine/Source/Editor/UnrealEd/Private/Commandlets/ContentCommandlets.cpp
+++ b/Engine/Source/Editor/UnrealEd/Private/Commandlets/ContentCommandlets.cpp
@@ -125,10 +125,10 @@ int32 UResavePackagesCommandlet::InitializeResaveParameters( const TArray<FStrin
             }
 			bExplicitPackages = true;
 		}
-		else if (FParse::Value(*CurrentSwitch, TEXT("MAP="), Maps))
+		//AMCHANGE_begin:
+		//#AMCHANGE Only re-package specific sub-levels
+		else if (FParse::Value(*CurrentSwitch, TEXT("MAP="), Maps, false))
 		{
-			//AMCHANGE_begin: 
-			//#AMCHANGE Only re-package specific sub-levels
 			TArray<FMapToRepackage> MapsToRepackage;
 			FindMapToRebuildFromParameters(Maps, MapsToRepackage);
 

--- a/Engine/Source/Editor/UnrealEd/Private/Commandlets/ContentCommandlets.cpp
+++ b/Engine/Source/Editor/UnrealEd/Private/Commandlets/ContentCommandlets.cpp
@@ -1535,7 +1535,7 @@ void UResavePackagesCommandlet::PerformAdditionalOperations(class UWorld* World,
 
 		//AMCHANGE_begin: 
 		//#AMCHANGE Only re-save specific sublevels
-		TArray<ULevelStreaming*> LevelStreamingsToRebuild;
+		TArray<ULevelStreaming*> StreamingLevelsToRebuild;
 		//AMCHANGE_end
 
 		if (bShouldProceedWithRebuild)
@@ -1622,7 +1622,7 @@ void UResavePackagesCommandlet::PerformAdditionalOperations(class UWorld* World,
 				//#AMCHANGE Only repackage specific sub-levels
 				StreamingLevel->bShouldBeVisibleInEditor = true;
 
-				LevelStreamingsToRebuild.Add(StreamingLevel);
+				StreamingLevelsToRebuild.Add(StreamingLevel);
 				//AMCHANGE_end
 			}
 		}
@@ -1745,7 +1745,7 @@ void UResavePackagesCommandlet::PerformAdditionalOperations(class UWorld* World,
 				//#AMCHANGE Only repackage specific sub-levels
 				LightingOptions.bOnlyBuildSelectedLevels = true;
 				LightingOptions.SelectedLevels.Add(World->PersistentLevel);
-				for (ULevelStreaming* LevelStreaming : LevelStreamingsToRebuild)
+				for (ULevelStreaming* LevelStreaming : StreamingLevelsToRebuild)
 				{
 					LightingOptions.SelectedLevels.Add(LevelStreaming->GetLoadedLevel());
 				}
@@ -1808,7 +1808,7 @@ void UResavePackagesCommandlet::PerformAdditionalOperations(class UWorld* World,
 			{
 				// AMCHANGE begin: Only repackage specific sub-levels
 				// Only save the packages that were repackaged
-				for (ULevelStreaming* NextStreamingLevel : LevelStreamingsToRebuild)
+				for (ULevelStreaming* NextStreamingLevel : StreamingLevelsToRebuild)
 				// AMCHANGE end
 				{
 					FString StreamingLevelPackageFilename;

--- a/Engine/Source/Editor/UnrealEd/Private/Commandlets/ContentCommandlets.cpp
+++ b/Engine/Source/Editor/UnrealEd/Private/Commandlets/ContentCommandlets.cpp
@@ -1284,6 +1284,16 @@ bool UResavePackagesCommandlet::CheckoutFile(const FString& Filename, bool bAddF
 	//FString FullPath = FPaths::ConvertRelativePathToFull(StreamingLevelPackageFilename);
 	ISourceControlProvider& SourceControlProvider = ISourceControlModule::Get().GetProvider();
 	FSourceControlStatePtr SourceControlState = SourceControlProvider.GetState(*Filename, EStateCacheUsage::ForceUpdate);
+
+	// AMCHANGE begin: Only repackage specific sub-levels
+	// If there is no source control setup, say that the checkout succeeded instead of failed.
+	// We can assume that the actions you would do on a checked out file are doable on a file that is not under version control
+	if (!SourceControlState.IsValid())
+	{
+		return true;
+	}
+	// AMCHANGE end
+
 	if (SourceControlState.IsValid())
 	{
 		FString CurrentlyCheckedOutUser;

--- a/Engine/Source/Editor/UnrealEd/Private/Commandlets/ContentCommandlets.cpp
+++ b/Engine/Source/Editor/UnrealEd/Private/Commandlets/ContentCommandlets.cpp
@@ -1796,7 +1796,10 @@ void UResavePackagesCommandlet::PerformAdditionalOperations(class UWorld* World,
 			// If everything is a success, resave the levels.
 			if( bShouldProceedWithRebuild )
 			{
-				for (ULevelStreaming* NextStreamingLevel : World->GetStreamingLevels())
+				// AMCHANGE begin: Only repackage specific sub-levels
+				// Only save the packages that were repackaged
+				for (ULevelStreaming* NextStreamingLevel : LevelStreamingsToRebuild)
+				// AMCHANGE end
 				{
 					FString StreamingLevelPackageFilename;
 					const FString StreamingLevelWorldAssetPackageName = NextStreamingLevel->GetWorldAssetPackageName();


### PR DESCRIPTION
- Most issues where that **logic wasn't migrated from our custom _Unreal Engine 4.19_**.
- There was also an **issue with saving the `BuildData` of the light built levels**. If there is no source control used, then the `BuildData` would never get saved.