### PR TITLE
Allow raytracing for scene capture components

### DIFF
--- a/Engine/Source/Runtime/Renderer/Private/DeferredShadingRenderer.cpp
+++ b/Engine/Source/Runtime/Renderer/Private/DeferredShadingRenderer.cpp
@@ -150,6 +150,18 @@ static TAutoConsoleVariable<int32> CVarForceAllRayTracingEffects(
 	TEXT(" 1: All ray tracing effects enabled"),
 	ECVF_RenderThreadSafe);
 
+//AMCHANGE_begin
+//#AMCHANGE Allow SceneCapture ray tracing if console variable is enabled
+static int32 GRayTracingSceneCaptures = 1;
+static FAutoConsoleVariableRef CVarRayTracingSceneCaptures(
+	TEXT("r.RayTracing.SceneCaptures"),
+	GRayTracingSceneCaptures,
+	TEXT("Enable ray tracing in scene captures.\n")
+	TEXT(" 0: off \n")
+	TEXT(" 1: on (default)"),
+	ECVF_RenderThreadSafe);
+//AMCHANGE_end
+
 static int32 GRayTracingExcludeDecals = 0;
 static FAutoConsoleVariableRef CRayTracingExcludeDecals(
 	TEXT("r.RayTracing.ExcludeDecals"),
@@ -687,12 +699,14 @@ bool FDeferredShadingSceneRenderer::GatherRayTracingWorldInstances(FRHICommandLi
 				{
 					continue;
 				}
-
+				//AMCHANGE_begin
+				//#AMCHANGE Allow SceneCapture ray tracing if console variable is enabled
 				if ((View.bIsReflectionCapture && !SceneInfo->bIsVisibleInReflectionCaptures)
-					|| View.bIsSceneCapture)
+					|| (View.bIsSceneCapture && GRayTracingSceneCaptures == 0))
 				{
 					continue;
 				}
+				//AMCHANGE_end
 
 				//#dxr_todo UE-68621  The Raytracing codepath does not support Showflags since data moved to the SceneInfo. 
 				//Touching the SceneProxy to determine this would simply cost too much


### PR DESCRIPTION
A UDN post asked how you could enable Ray tracing support for SceneCapture components. 
Another person replied that you could use the r.RayTracing.SceneCaptures command to enable support.

However I could not find that anywhere in the unreal repo. So by searching on github I came across this:
https://github.com/pymc20/unreal/blob/3ea5bbb937f5804c10e1101e0c6408824d449a88/Engine/Source/Runtime/Renderer/Private/DeferredShadingRenderer.cpp

Those are the changes I implemented. And it worked.