### PR TITLE
Ds 7647/reverted engine changes webbrowser

### DIFF
--- a/Engine/Source/Runtime/WebBrowser/Private/WebBrowserSingleton.cpp
+++ b/Engine/Source/Runtime/WebBrowser/Private/WebBrowserSingleton.cpp
@@ -250,11 +250,14 @@ FWebBrowserSingleton::FWebBrowserSingleton(const FWebBrowserInitSettings& WebBro
 	Settings.command_line_args_disabled = true;
 #if !PLATFORM_LINUX
 	Settings.enable_net_security_expiration = true;
-	Settings.external_message_pump = true;
+
+	//AMCHANGE_begin: 
+//#AMCHANGE CEF get stuck sometimes on the external pump logic, disabling it again so it's the same logic as in UE4.19
+	//Settings.external_message_pump = true;
 #endif
 	//@todo change to threaded version instead of using external_message_pump & OnScheduleMessagePumpWork
-	Settings.multi_threaded_message_loop = false;
-	
+	//Settings.multi_threaded_message_loop = false;
+	//AMCHANGE_end
 
 	FString CefLogFile(FPaths::Combine(*FPaths::ProjectLogDir(), TEXT("cef3.log")));
 	CefLogFile = FPaths::ConvertRelativePathToFull(CefLogFile);
@@ -641,16 +644,20 @@ bool FWebBrowserSingleton::Tick(float DeltaTime)
 			}
 		}
 	}
+	//AMCHANGE_begin: 
+	//#AMCHANGE CEF get stuck sometimes on the external pump logic, disabling it again so it's the same logic as in UE4.19
+	//bool bForceMessageLoop = false;
+	//GConfig->GetBool(TEXT("Browser"), TEXT("bForceMessageLoop"), bForceMessageLoop, GEngineIni);
+	//if (CEFBrowserApp != nullptr)
+	//{
+	//	// force via config override or if there are active browser windows
+	//	const bool bForce = bForceMessageLoop || WindowInterfaces.Num() > 0;
+	//	// tick the CEF app to determine when to run CefDoMessageLoopWork
+	//	CEFBrowserApp->TickMessagePump(DeltaTime, bForce);
+	//}
 
-	bool bForceMessageLoop = false;
-	GConfig->GetBool(TEXT("Browser"), TEXT("bForceMessageLoop"), bForceMessageLoop, GEngineIni);
-	if (CEFBrowserApp != nullptr)
-	{
-		// force via config override or if there are active browser windows
-		const bool bForce = bForceMessageLoop || WindowInterfaces.Num() > 0;
-		// tick the CEF app to determine when to run CefDoMessageLoopWork
-		CEFBrowserApp->TickMessagePump(DeltaTime, bForce);
-	}
+	CefDoMessageLoopWork();
+	//AMCHANGE_end: 
 
 	// Update video buffering for any windows that need it
 	for (int32 Index = 0; Index < WindowInterfaces.Num(); Index++)


### PR DESCRIPTION
Reverted changes that were made to the CEF webbrowser implementation because the browser sometimes just froze.
Disabled the 'external_message_pump': when this flag is set to false, CEF uses his own ticking logic, if it's set to true you should implement your own ticking logic for CEF.
For some reason epic changed the implementation to use this external message pump, but this makes the browser freeze somethimes. So I reverted the implementation back to the way it was in 4.19.
