### PR TITLE
Changes to remove startup packages from being cooked when we export a…

### DIFF
--- a/Engine/Source/Editor/UnrealEd/Classes/CookOnTheSide/CookOnTheFlyServer.h
+++ b/Engine/Source/Editor/UnrealEd/Classes/CookOnTheSide/CookOnTheFlyServer.h
@@ -367,8 +367,11 @@ public:
 
 	/**
 	* Get any packages which are in memory, these were probably required to be loaded because of the current package we are cooking, so we should probably cook them also
-	*/
-	TArray<UPackage*> GetUnsolicitedPackages(const TArray<FName>& TargetPlatformNames) const;
+	*/	
+//AMCHANGE_begin
+//#AMCHANGE Set to virtual to change it in child class
+	virtual TArray<UPackage*> GetUnsolicitedPackages(const TArray<FName>& TargetPlatformNames) const;
+//AMCHANGE_end
 
 	/**
 	* PostLoadPackageFixup

--- a/Engine/Source/Editor/UnrealEd/Private/CookOnTheFlyServer.cpp
+++ b/Engine/Source/Editor/UnrealEd/Private/CookOnTheFlyServer.cpp
@@ -5596,12 +5596,12 @@ void UCookOnTheFlyServer::EmptyPackageLists()
 	PackageTracker->LoadedPackages.Empty();
 	PackageTracker->NewPackages.Empty();
 
-	// We don't to want startup packages
+	// We don't to want startup packages because they only contain assets that are included with the base game.
 	CookByTheBookOptions->StartupPackages.Empty();
 
 	//Calling this removes the default startup packages from the internal map in the GRedirectCollector
-	TSet<FName> StartupSoftObjectPackages;
-	GRedirectCollector.ProcessSoftObjectPathPackageList(NAME_None, false, StartupSoftObjectPackages);
+	TSet<FName> StartupPackageNames;
+	GRedirectCollector.ProcessSoftObjectPathPackageList(NAME_None, false, StartupPackageNames);
 
 }
 //AMCHANGE_end

--- a/Engine/Source/Editor/UnrealEd/Private/CookOnTheFlyServer.cpp
+++ b/Engine/Source/Editor/UnrealEd/Private/CookOnTheFlyServer.cpp
@@ -5586,6 +5586,7 @@ void UCookOnTheFlyServer::GenerateLongPackageNames(TArray<FName>& FilesInPath)
 	FilesInPath.Append(FilesInPathReverse);
 }
 
+//AMCHANGE_begin
 void UCookOnTheFlyServer::EmptyPackageLists()
 {
 	// We empty this list because otherwise it results in certain assets not cooked
@@ -5594,7 +5595,16 @@ void UCookOnTheFlyServer::EmptyPackageLists()
 	// We empty these lists because otherwise too many items are cooked
 	PackageTracker->LoadedPackages.Empty();
 	PackageTracker->NewPackages.Empty();
+
+	// We don't to want startup packages
+	CookByTheBookOptions->StartupPackages.Empty();
+
+	//Calling this removes the default startup packages from the internal map in the GRedirectCollector
+	TSet<FName> StartupSoftObjectPackages;
+	GRedirectCollector.ProcessSoftObjectPathPackageList(NAME_None, false, StartupSoftObjectPackages);
+
 }
+//AMCHANGE_end
 
 void UCookOnTheFlyServer::AddFileToCook( TArray<FName>& InOutFilesToCook, const FString &InFilename ) const
 { 
@@ -7142,6 +7152,10 @@ void UCookOnTheFlyServer::StartCookByTheBook( const FCookByTheBookStartupOptions
 	TArray<FName> FilesInPath;
 	TSet<FName> StartupSoftObjectPackages;
 
+//AMCHANGE_Begin
+// Change the order so we can clear the startup packages in collectfilestocook function
+	CollectFilesToCook(FilesInPath, CookMaps, CookDirectories, IniMapSections, CookOptions);
+
 	// Get the list of soft references, for both empty package and all startup packages
 	GRedirectCollector.ProcessSoftObjectPathPackageList(NAME_None, false, StartupSoftObjectPackages);
 
@@ -7150,7 +7164,8 @@ void UCookOnTheFlyServer::StartCookByTheBook( const FCookByTheBookStartupOptions
 		GRedirectCollector.ProcessSoftObjectPathPackageList(StartupPackage, false, StartupSoftObjectPackages);
 	}
 
-	CollectFilesToCook(FilesInPath, CookMaps, CookDirectories, IniMapSections, CookOptions);
+	
+//AMCHANGE_End
 
 	// Add string asset packages after collecting files, to avoid accidentally activating the behavior to cook all maps if none are specified
 	for (FName SoftObjectPackage : StartupSoftObjectPackages)


### PR DESCRIPTION
Changes to remove startup packages from being cooked when we export assets or scenes.

I changed the EmptyPackageList function to remove more startup packages when we export assets or scenes. I also made the GetUnsolicitedPackages function virtual so we can better filter out invalid assets that should not be cooked.