### PR TITLE
Added action to create precompiled engine on commit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: trigger engine jenkins job
+on:
+  # Trigger the workflow on push,
+  # but only for the addChangesFromVXGI4.19 branch
+  push:
+    branches:
+      - Features/addChangesFromVXGI4.19
+jobs:
+  curl:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: jenkins
+      uses: enflo/jenkins-action@master
+      with:
+        url: "http://jenkins.vr-tual.media:8080"
+        user: "alfred"
+        token: ${{ secrets.JENKINS_TOKEN }}
+        job: "/job/engine-build-pipeline"
+        parameters: "Engine%20archive%20name="


### PR DESCRIPTION
Added a github action that triggers the jenkins build of job engine-build-pipeline.
This means everytime we push to Features/addChangesFromVXGI4.19 a new precompiled engine should be created.
If you have questions let me know.