### PR TITLE
 Fix for crash on streaming servers, this field is defined in DX12 AP…

### DIFF
--- a/Engine/Source/Runtime/D3D12RHI/Private/D3D12PipelineState.h
+++ b/Engine/Source/Runtime/D3D12RHI/Private/D3D12PipelineState.h
@@ -46,6 +46,10 @@ struct FD3D12_GRAPHICS_PIPELINE_STATE_DESC
 	D3D12_SHADER_BYTECODE DS;
 	D3D12_SHADER_BYTECODE HS;
 	D3D12_SHADER_BYTECODE GS;
+	//AMCHANGE_begin
+    //#AMCHANGE Fix for crash on servers, this field is defined in DX12 API, but wasn't included in the ue4 implementation of it. Adding it fixed the crash
+	D3D12_STREAM_OUTPUT_DESC StreamOutput;
+	//AMCHANGE_end
 #if !D3D12_USE_DERIVED_PSO
 	D3D12_BLEND_DESC BlendState;
 	uint32 SampleMask;

--- a/Engine/Source/Runtime/D3D12RHI/Private/D3D12PipelineState.h
+++ b/Engine/Source/Runtime/D3D12RHI/Private/D3D12PipelineState.h
@@ -47,7 +47,8 @@ struct FD3D12_GRAPHICS_PIPELINE_STATE_DESC
 	D3D12_SHADER_BYTECODE HS;
 	D3D12_SHADER_BYTECODE GS;
 	//AMCHANGE_begin
-    //#AMCHANGE Fix for crash on servers, this field is defined in DX12 API, but wasn't included in the ue4 implementation of it. Adding it fixed the crash
+	//#AMCHANGE Fix for crash on cards used on streaming servers (e.g. NVIDIA M60 or P4 cards), this field is defined in DX12 API, but wasn't included in the ue4 implementation of it. 
+	// These cards don't use the 'pipeline streams' flow (used on most cards), so it only crashes on these cards. Adding the missing field fixed the crash
 	D3D12_STREAM_OUTPUT_DESC StreamOutput;
 	//AMCHANGE_end
 #if !D3D12_USE_DERIVED_PSO

--- a/Engine/Source/Runtime/D3D12RHI/Private/Windows/WindowsD3D12PipelineState.cpp
+++ b/Engine/Source/Runtime/D3D12RHI/Private/Windows/WindowsD3D12PipelineState.cpp
@@ -81,7 +81,8 @@ D3D12_GRAPHICS_PIPELINE_STATE_DESC FD3D12_GRAPHICS_PIPELINE_STATE_DESC::Graphics
 	D.DS = this->DS;
 	D.PS = this->PS;
 	//AMCHANGE_begin
-	//#AMCHANGE Fix for crash on servers, this field is defined in DX12 API, but wasn't included in the ue4 implementation of it. Adding it fixed the crash
+	//#AMCHANGE Fix for crash on cards used on streaming servers (e.g. NVIDIA M60 or P4 cards), this field is defined in DX12 API, but wasn't included in the ue4 implementation of it. 
+	// These cards don't use the 'pipeline streams' flow (used on most cards), so it only crashes on these cards. Adding the missing field fixed the crash
 	D.StreamOutput = this->StreamOutput;
 	//AMCHANGE_end
 	D.BlendState = this->BlendState;

--- a/Engine/Source/Runtime/D3D12RHI/Private/Windows/WindowsD3D12PipelineState.cpp
+++ b/Engine/Source/Runtime/D3D12RHI/Private/Windows/WindowsD3D12PipelineState.cpp
@@ -80,6 +80,10 @@ D3D12_GRAPHICS_PIPELINE_STATE_DESC FD3D12_GRAPHICS_PIPELINE_STATE_DESC::Graphics
 	D.HS = this->HS;
 	D.DS = this->DS;
 	D.PS = this->PS;
+	//AMCHANGE_begin
+	//#AMCHANGE Fix for crash on servers, this field is defined in DX12 API, but wasn't included in the ue4 implementation of it. Adding it fixed the crash
+	D.StreamOutput = this->StreamOutput;
+	//AMCHANGE_end
 	D.BlendState = this->BlendState;
 	D.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC1(this->DepthStencilState);
 	D.DSVFormat = this->DSVFormat;


### PR DESCRIPTION
…I, but wasn't included in the ue4 implementation of it. Adding it fixed the crash