### PR TITLE
Revert "Increase download speed of big files."

### DIFF
--- a/Engine/Source/Runtime/Online/HTTP/Private/Curl/CurlHttpThread.cpp
+++ b/Engine/Source/Runtime/Online/HTTP/Private/Curl/CurlHttpThread.cpp
@@ -25,20 +25,7 @@ void FCurlHttpThread::HttpThreadTick(float DeltaSeconds)
 			int RunningRequests = -1;
 			{
 				QUICK_SCOPE_CYCLE_COUNTER(STAT_FCurlHttpThread_HttpThreadTick_Perform);
-				
-				//AMCHANGE_begin: 
-				//#AMCHANGE CurlHttp is by default much slower to download big files than the old WinInet that was used in UE4.19
-				// This is a temporary workaround to bring the download speed to a similar rate as WinInet. 
-				// This is why 10 was chosen as number, only through trial and errors.
-				// You can follow the exact reasons why this is needed in two places: 
-				// UDN: https://udn.unrealengine.com/questions/556090/view.html
-				// JIRA: https://aroundmedia.atlassian.net/browse/DS-7781
-				int8 nbOfUpdatesToExactMoreDataPerTick = 10;
-				for (int8 i = 0; i < nbOfUpdatesToExactMoreDataPerTick; ++i)
-				{
-					curl_multi_perform(FCurlHttpManager::GMultiHandle, &RunningRequests);
-				}
-				// AMCHANGE_end
+				curl_multi_perform(FCurlHttpManager::GMultiHandle, &RunningRequests);
 			}
 
 			// read more info if number of requests changed or if there's zero running


### PR DESCRIPTION
- Remove the temporary fix that was done to increase download speed as this can be done through a setting in the http module. This setting will be set in the project instead of the engine.
- See [UDN question](https://udn.unrealengine.com/questions/556090/curlhttp-slow-when-downloading-big-files.html) for complete explanation.

This reverts commit b3c39e10c33d80848208fbc224ed83d0a91b1c6b.