### PR TITLE
Bug fix/fix compilation vs2019

### DIFF
--- a/Engine/Plugins/Runtime/Database/ADOSupport/Source/ADOSupport/Private/ADOSupport.cpp
+++ b/Engine/Plugins/Runtime/Database/ADOSupport/Source/ADOSupport/Private/ADOSupport.cpp
@@ -252,7 +252,7 @@ public:
 	/** Destructor, cleaning up ADO record set. */
 	virtual ~FADODataBaseRecordSet()
 	{
-		if(ADORecordSet && (ADORecordSet->State & ADODB::adStateOpen))
+		if(ADORecordSet != nullptr && (ADORecordSet->State & ADODB::adStateOpen))
 		{
 			// We're using smart pointers so all we need to do is close and assign NULL.
 			ADORecordSet->Close();
@@ -325,7 +325,7 @@ public:
 	virtual void Close()
 	{
 		// Close database connection if exists and free smart pointer.
-		if( DataBaseConnection && (DataBaseConnection->State & ADODB::adStateOpen))
+		if( DataBaseConnection != nullptr && (DataBaseConnection->State & ADODB::adStateOpen))
 		{
 			DataBaseConnection->Close();
 

--- a/Engine/Source/Developer/Windows/LiveCodingServer/Private/External/LC_LiveProcess.cpp
+++ b/Engine/Source/Developer/Windows/LiveCodingServer/Private/External/LC_LiveProcess.cpp
@@ -62,7 +62,7 @@ void LiveProcess::HandleDebuggingPreCompile(void)
 		// this process did not make progress.
 		// try to find a debugger that's currently debugging our process.
 		m_vsDebugger = visualStudio::FindDebuggerForProcess(m_processId);
-		if (m_vsDebugger)
+		if (m_vsDebugger != nullptr)
 		{
 			// found a debugger.
 			// enumerate all threads, freeze every thread but the command thread, and let the debugger resume.
@@ -101,7 +101,7 @@ void LiveProcess::HandleDebuggingPostCompile(void)
 		UninstallCodeCave();
 	}
 #if WITH_VISUALSTUDIO_DTE
-	else if (m_vsDebugger)
+	else if (m_vsDebugger != nullptr)
 	{
 		// we automated the debugger previously. break into the debugger again and resume all threads.
 		// when debugging a C# project that calls into C++ code, the VS debugger sometimes creates new MTA threads in between our PreCompile and PostCompile calls.

--- a/Engine/Source/Developer/Windows/LiveCodingServer/Private/External/LC_ServerCommandThread.cpp
+++ b/Engine/Source/Developer/Windows/LiveCodingServer/Private/External/LC_ServerCommandThread.cpp
@@ -194,7 +194,7 @@ void ServerCommandThread::RestartTargets(void)
 			// check if a VS debugger is currently attached to the process about to restart
 			const unsigned int processId = liveProcess->GetProcessId();
 			EnvDTE::DebuggerPtr debugger = visualStudio::FindDebuggerAttachedToProcess(processId);
-			if (debugger)
+			if (debugger != nullptr)
 			{
 				m_restartedProcessIdToDebugger.emplace(processId, debugger);
 			}

--- a/Engine/Source/Developer/Windows/LiveCodingServer/Private/External/LC_VisualStudioAutomation.cpp
+++ b/Engine/Source/Developer/Windows/LiveCodingServer/Private/External/LC_VisualStudioAutomation.cpp
@@ -106,7 +106,7 @@ static EnvDTE::DebuggerPtr FindDebuggerAttachedToProcess(unsigned int processId)
 
 				EnvDTE::_DTEPtr dte = nullptr;
 				result = unknown->QueryInterface(&dte);
-				if (FAILED(result) || (!dte))
+				if (FAILED(result) || (dte == nullptr))
 				{
 					// this COM object doesn't support the DTE interface
 					LC_ERROR_DEV("Could not convert IUnknown to DTE interface. Error: 0x%X", result);
@@ -115,7 +115,7 @@ static EnvDTE::DebuggerPtr FindDebuggerAttachedToProcess(unsigned int processId)
 
 				EnvDTE::DebuggerPtr debugger = nullptr;
 				result = dte->get_Debugger(&debugger);
-				if (FAILED(result) || (!debugger))
+				if (FAILED(result) || (debugger == nullptr))
 				{
 					// cannot access debugger, which means that the process is currently not being debugged
 					LC_LOG_DEV("Could not access debugger interface. Error: 0x%X", result);
@@ -125,7 +125,7 @@ static EnvDTE::DebuggerPtr FindDebuggerAttachedToProcess(unsigned int processId)
 				// fetch all processes to which this debugger is attached
 				EnvDTE::ProcessesPtr allProcesses = nullptr;
 				result = debugger->get_DebuggedProcesses(&allProcesses);
-				if (FAILED(result) || (!allProcesses))
+				if (FAILED(result) || (allProcesses == nullptr))
 				{
 					LC_ERROR_DEV("Could not retrieve processes from debugger. Error: 0x%X", result);
 					continue;
@@ -145,7 +145,7 @@ static EnvDTE::DebuggerPtr FindDebuggerAttachedToProcess(unsigned int processId)
 					EnvDTE::ProcessPtr singleProcess = nullptr;
 					result = allProcesses->Item(variant_t(i + 1), &singleProcess);
 
-					if (FAILED(result) || (!singleProcess))
+					if (FAILED(result) || (singleProcess == nullptr))
 					{
 						LC_ERROR_DEV("Could not retrieve process from debugger. Error: 0x%X", result);
 						continue;
@@ -246,7 +246,7 @@ static EnvDTE::DebuggerPtr FindDebuggerForProcess(unsigned int processId)
 
 				EnvDTE::_DTEPtr dte = nullptr;
 				result = unknown->QueryInterface(&dte);
-				if (FAILED(result) || (!dte))
+				if (FAILED(result) || (dte == nullptr))
 				{
 					// this COM object doesn't support the DTE interface
 					LC_ERROR_DEV("Could not convert IUnknown to DTE interface. Error: 0x%X", result);
@@ -255,7 +255,7 @@ static EnvDTE::DebuggerPtr FindDebuggerForProcess(unsigned int processId)
 
 				EnvDTE::DebuggerPtr debugger = nullptr;
 				result = dte->get_Debugger(&debugger);
-				if (FAILED(result) || (!debugger))
+				if (FAILED(result) || (debugger == nullptr))
 				{
 					// cannot access debugger, which means that the process is currently not being debugged
 					LC_LOG_DEV("Could not access debugger interface. Error: 0x%X", result);
@@ -264,7 +264,7 @@ static EnvDTE::DebuggerPtr FindDebuggerForProcess(unsigned int processId)
 
 				EnvDTE::ProcessPtr process = nullptr;
 				result = debugger->get_CurrentProcess(&process);
-				if (FAILED(result) || (!process))
+				if (FAILED(result) || (process == nullptr))
 				{
 					// cannot access current process, reason unknown
 					LC_ERROR_DEV("Could not access current process in debugger. Error: 0x%X", result);
@@ -305,7 +305,7 @@ static bool AttachToProcess(const EnvDTE::DebuggerPtr& debugger, unsigned int pr
 	// fetch all local processes running on this machine
 	EnvDTE::ProcessesPtr allProcesses = nullptr;
 	HRESULT result = debugger->get_LocalProcesses(&allProcesses);
-	if (FAILED(result) || (!allProcesses))
+	if (FAILED(result) || (allProcesses == nullptr))
 	{
 		LC_ERROR_DEV("Could not retrieve local processes from debugger. Error: 0x%X", result);
 		return false;
@@ -325,7 +325,7 @@ static bool AttachToProcess(const EnvDTE::DebuggerPtr& debugger, unsigned int pr
 		EnvDTE::ProcessPtr singleProcess = nullptr;
 		result = allProcesses->Item(variant_t(i + 1), &singleProcess);
 
-		if (FAILED(result) || (!singleProcess))
+		if (FAILED(result) || (singleProcess == nullptr))
 		{
 			LC_ERROR_DEV("Could not retrieve local process from debugger. Error: 0x%X", result);
 			continue;
@@ -370,7 +370,7 @@ static types::vector<EnvDTE::ThreadPtr> EnumerateThreads(const EnvDTE::DebuggerP
 
 	EnvDTE::ProgramPtr program = nullptr;
 	HRESULT result = debugger->get_CurrentProgram(&program);
-	if (FAILED(result) || (!program))
+	if (FAILED(result) || program == nullptr)
 	{
 		LC_ERROR_DEV("Could not retrieve current program from debugger. Error: 0x%X", result);
 		return threads;
@@ -378,7 +378,7 @@ static types::vector<EnvDTE::ThreadPtr> EnumerateThreads(const EnvDTE::DebuggerP
 
 	EnvDTE::ThreadsPtr allThreads = nullptr;
 	result = program->get_Threads(&allThreads);
-	if (FAILED(result) || (!allThreads))
+	if (FAILED(result) || allThreads == nullptr)
 	{
 		LC_ERROR_DEV("Could not retrieve running threads from debugger. Error: 0x%X", result);
 		return threads;
@@ -398,7 +398,7 @@ static types::vector<EnvDTE::ThreadPtr> EnumerateThreads(const EnvDTE::DebuggerP
 	{
 		EnvDTE::ThreadPtr singleThread = nullptr;
 		result = allThreads->Item(variant_t(i + 1), &singleThread);
-		if (FAILED(result) || (!singleThread))
+		if (FAILED(result) || (singleThread == nullptr))
 		{
 			LC_ERROR_DEV("Could not retrieve thread from debugger. Error: 0x%X", result);
 			continue;


### PR DESCRIPTION
This PR aims at allowing compiling the engine with VS2019. I decided to do this because we use VS2019 for development now and the fixes weren't too long to implement.

The issues are related to changes done in the std library by microsoft for the VS2019 16.5 version. One of the smart pointer could not be default converted to a `bool` anymore. To fix this, we have to explicitly compare the pointer with `nullptr`. 

There is a more details in the commit messages.
