### PR TITLE
Specify materials names in FExportableMeshSection

### DIFF
--- a/Engine/Plugins/Marketplace/RuntimeMeshImportExport/Source/RuntimeMeshImportExport/Public/RuntimeMeshImportExportTypes.h
+++ b/Engine/Plugins/Marketplace/RuntimeMeshImportExport/Source/RuntimeMeshImportExport/Public/RuntimeMeshImportExportTypes.h
@@ -178,6 +178,13 @@ struct FExportableMeshMaterial
 	GENERATED_BODY()
 
 	/**
+	 * Name of the material that will be used by this mesh.
+	 * It should be unique amongst all materials in the scene otherwise the mesh might use the other material with the same name.
+	 */
+	UPROPERTY(BlueprintReadWrite, Category = "Default")
+	FString uniqueName;
+	
+	/**
 	 * Path of the diffuse texture used by the material
 	 * The path is relative to the location of the 3D file
 	 * Should include the extension of the file.


### PR DESCRIPTION
Before, the code was using the memory address of the materials to know
if a mesh was reusing a material from the scene or not. It was also
using the 'GetName()' of the UMaterialInterface to set the
AI_MATKEY_NAME attribute of the Assimp material.

Now, it is instead relying on a name that is passed in the
'materialToExport' struct within 'FExportableMeshSection'.
This change allows the code using the exporter to define the names that
the materials should receive in the 3D file.