### PR TITLE
Crash if assimp dll failed to load

### DIFF
--- a/Engine/Plugins/Marketplace/RuntimeMeshImportExport/Source/RuntimeMeshImportExport/Private/RuntimeMeshImportExport.cpp
+++ b/Engine/Plugins/Marketplace/RuntimeMeshImportExport/Source/RuntimeMeshImportExport/Private/RuntimeMeshImportExport.cpp
@@ -38,8 +38,17 @@ void FRuntimeMeshImportExportModule::StartupModule()
 	{
 		RMIE_LOG(Fatal, "Missing file: %s", *dllFile);
 	}
-		
+
+	//AMCHANGE_begin
+	//#AMCHANGE Add validation to detect when the assimp dll failed to load
+	//			One of the reason making this fail is the error 206: the path to the dll is too long. It can be other causes though.
+	//			In all cases, it's better to detect this problem early than to crash when trying to use the dll.
 	dllHandle_assimp = FPlatformProcess::GetDllHandle(*dllFile);
+	if (!dllHandle_assimp)
+	{
+		RMIE_LOG(Fatal, "Failed to load the required '%s' dll. The application will now close.", *dllFileName);
+	}
+	//AMCHANGE_end
 }
 
 void FRuntimeMeshImportExportModule::ShutdownModule()


### PR DESCRIPTION
Before, if the assimp dll failed to load, it would only crash when
trying to use it. This means that the problem is noticed very late and
there is no clear error message to the user.

Forcing a crash if the assimp dll failed to be loaded makes sure the
user has an error message to report to us. Detecting a problem early
makes it easier to detect and debug.