### PR TITLE
Features/add metalness to exportable material

### DIFF
--- a/Engine/Plugins/Marketplace/RuntimeMeshImportExport/Source/RuntimeMeshImportExport/Private/AssimpCustom.cpp
+++ b/Engine/Plugins/Marketplace/RuntimeMeshImportExport/Source/RuntimeMeshImportExport/Private/AssimpCustom.cpp
@@ -412,6 +412,14 @@ void FAssimpNode::CreateAssimpMeshesFromMeshData(FAssimpScene& scene, const FRun
 						material->AddProperty(&diffuseTextureRelativePath, AI_MATKEY_TEXTURE(aiTextureType_DIFFUSE, 0));
 					}
 				}
+				// Set the metalness texture of the material
+				{
+					if (!section.materialToExport.metalnessTextureRelativePath.IsEmpty())
+					{
+						const aiString metalnessTextureRelativePath(TCHAR_TO_UTF8(*section.materialToExport.metalnessTextureRelativePath));
+						material->AddProperty(&metalnessTextureRelativePath, AI_MATKEY_TEXTURE(aiTextureType_METALNESS, 0));
+					}
+				}
             	// Set the normals texture of the material
                 {
 	                if (!section.materialToExport.normalsTextureRelativePath.IsEmpty())
@@ -420,7 +428,8 @@ void FAssimpNode::CreateAssimpMeshesFromMeshData(FAssimpScene& scene, const FRun
 						material->AddProperty(&normalsTextureRelativePath, AI_MATKEY_TEXTURE(aiTextureType_NORMALS, 0));
 	                }
                 }
-            	// Set the opacity of the material (only if it is not 1.0, which means it  is fully opaque)
+				
+				// Set the opacity of the material (only if it is not 1.0, which means it  is fully opaque)
                 {
 					float opacity = section.materialToExport.opacity;
 					if (opacity < 1.0)

--- a/Engine/Plugins/Marketplace/RuntimeMeshImportExport/Source/RuntimeMeshImportExport/Private/AssimpCustom.cpp
+++ b/Engine/Plugins/Marketplace/RuntimeMeshImportExport/Source/RuntimeMeshImportExport/Private/AssimpCustom.cpp
@@ -413,14 +413,6 @@ void FAssimpNode::CreateAssimpMeshesFromMeshData(FAssimpScene& scene, const FRun
 						material->AddProperty(&diffuseTextureRelativePath, AI_MATKEY_TEXTURE(aiTextureType_DIFFUSE, 0));
 					}
 				}
-				// Set the metalness texture of the material
-				{
-					if (!section.materialToExport.metalnessTextureRelativePath.IsEmpty())
-					{
-						const aiString metalnessTextureRelativePath(TCHAR_TO_UTF8(*section.materialToExport.metalnessTextureRelativePath));
-						material->AddProperty(&metalnessTextureRelativePath, AI_MATKEY_TEXTURE(aiTextureType_METALNESS, 0));
-					}
-				}
             	// Set the normals texture of the material
                 {
 	                if (!section.materialToExport.normalsTextureRelativePath.IsEmpty())

--- a/Engine/Plugins/Marketplace/RuntimeMeshImportExport/Source/RuntimeMeshImportExport/Private/AssimpCustom.cpp
+++ b/Engine/Plugins/Marketplace/RuntimeMeshImportExport/Source/RuntimeMeshImportExport/Private/AssimpCustom.cpp
@@ -4,6 +4,7 @@
 
 #include "AssimpCustom.h"
 #include "Async/Async.h"
+#include "assimp/pbrmaterial.h"
 #include "RuntimeMeshImportExport.h"
 #include "RuntimeMeshImportExportLibrary.h"
 #include "RuntimeMeshImportExportTypes.h"
@@ -428,6 +429,18 @@ void FAssimpNode::CreateAssimpMeshesFromMeshData(FAssimpScene& scene, const FRun
 						material->AddProperty(&normalsTextureRelativePath, AI_MATKEY_TEXTURE(aiTextureType_NORMALS, 0));
 	                }
                 }
+				// Set metallicRoughness map
+				{
+					if (!section.materialToExport.gltfMetallicRoughnessTextureRelativePath.IsEmpty())
+					{
+						const aiString gltfMetallicRoughnessTextureRelativePath(TCHAR_TO_UTF8(*section.materialToExport.gltfMetallicRoughnessTextureRelativePath));
+						material->AddProperty(&gltfMetallicRoughnessTextureRelativePath, AI_MATKEY_TEXTURE(aiTextureType_UNKNOWN, 0));
+					}
+
+					float metallicFactor = section.materialToExport.metallicFactor;
+					material->AddProperty(&metallicFactor, 1, AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_METALLIC_FACTOR);
+				}
+
 				
 				// Set the opacity of the material (only if it is not 1.0, which means it  is fully opaque)
                 {

--- a/Engine/Plugins/Marketplace/RuntimeMeshImportExport/Source/RuntimeMeshImportExport/Private/AssimpCustom.cpp
+++ b/Engine/Plugins/Marketplace/RuntimeMeshImportExport/Source/RuntimeMeshImportExport/Private/AssimpCustom.cpp
@@ -426,7 +426,8 @@ void FAssimpNode::CreateAssimpMeshesFromMeshData(FAssimpScene& scene, const FRun
 					if (!section.materialToExport.gltfMetallicRoughnessTextureRelativePath.IsEmpty())
 					{
 						const aiString gltfMetallicRoughnessTextureRelativePath(TCHAR_TO_UTF8(*section.materialToExport.gltfMetallicRoughnessTextureRelativePath));
-						material->AddProperty(&gltfMetallicRoughnessTextureRelativePath, AI_MATKEY_TEXTURE(aiTextureType_UNKNOWN, 0));
+						const aiTextureType aiTextureType_GLTF_METALLICROUGHNESS_TEXTURE = aiTextureType_UNKNOWN;
+						material->AddProperty(&gltfMetallicRoughnessTextureRelativePath, AI_MATKEY_TEXTURE(aiTextureType_GLTF_METALLICROUGHNESS_TEXTURE, 0));
 					}
 
 					float metallicFactor = section.materialToExport.metallicFactor;

--- a/Engine/Plugins/Marketplace/RuntimeMeshImportExport/Source/RuntimeMeshImportExport/Public/RuntimeMeshImportExportTypes.h
+++ b/Engine/Plugins/Marketplace/RuntimeMeshImportExport/Source/RuntimeMeshImportExport/Public/RuntimeMeshImportExportTypes.h
@@ -201,6 +201,20 @@ struct FExportableMeshMaterial
 	FString metalnessTextureRelativePath;
 	
 	/**
+	 * Factor of metalness 0 is non metal, 1 is metal
+	 */
+	UPROPERTY(BlueprintReadWrite, Category = "Default")
+	float metallicFactor = 1.0f;
+
+	/**
+	* Path of the metallic-roughness texture used by the material
+	* The path is relative to the location of the 3D file
+	* Should include the extension of the file.
+	*/
+	UPROPERTY(BlueprintReadWrite, Category = "Default")
+	FString gltfMetallicRoughnessTextureRelativePath;
+
+	/**
 	* Path of the normals texture used by the material
 	* The path is relative to the location of the 3D file
 	* Should include the extension of the file.

--- a/Engine/Plugins/Marketplace/RuntimeMeshImportExport/Source/RuntimeMeshImportExport/Public/RuntimeMeshImportExportTypes.h
+++ b/Engine/Plugins/Marketplace/RuntimeMeshImportExport/Source/RuntimeMeshImportExport/Public/RuntimeMeshImportExportTypes.h
@@ -193,13 +193,21 @@ struct FExportableMeshMaterial
 	FString diffuseTextureRelativePath;
 
 	/**
+	* Path of the metalness texture used by the material
+	* The path is relative to the location of the 3D file
+	* Should include the extension of the file.
+	*/
+	UPROPERTY(BlueprintReadWrite, Category = "Default")
+	FString metalnessTextureRelativePath;
+	
+	/**
 	* Path of the normals texture used by the material
 	* The path is relative to the location of the 3D file
 	* Should include the extension of the file.
 	*/
 	UPROPERTY(BlueprintReadWrite, Category = "Default")
 	FString normalsTextureRelativePath;
-
+	
 	/**
 	 * Opacity of the material. 1.0 means fully opaque while 0.0 means fully transparent.
 	 */


### PR DESCRIPTION
Added MetallicRougnessTexture and MetallicFactor to the exporter.

These are required to have a GLTF export with working Metallic and Rougness values.